### PR TITLE
Sha256

### DIFF
--- a/faycsic/main/CMakeLists.txt
+++ b/faycsic/main/CMakeLists.txt
@@ -1,2 +1,7 @@
-idf_component_register(SRCS "main.c"
-                    INCLUDE_DIRS ".")
+message(STATUS "Compiling SRCS: ${SRCS}")
+idf_component_register(
+SRCS 
+    "hash.c" 
+    "main.c"
+INCLUDE_DIRS "."
+)

--- a/faycsic/main/hash.c
+++ b/faycsic/main/hash.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include "mbedtls/sha256.h"
+
+
+
+// Convert a byte array to a hex string for readability (optional)
+void to_hex(unsigned char *hash, char output[]) {
+    for (int i = 0; i < 32; i++) {
+        sprintf(output + (i * 2), "%02x", hash[i]);
+    }
+}
+
+// Perform double SHA-256 hashing
+void double_sha256(unsigned char *input, size_t len, uint8_t output[32]) {
+    unsigned char temp[32];
+
+    mbedtls_sha256(input, strlen((const char *)input), temp,0);
+    mbedtls_sha256(temp, strlen((const char *)temp), output,0);
+}
+
+int hash(unsigned char target[32], uint8_t block_header[80]) {
+    char target_output[32 * 2 + 1];
+    to_hex(target, target_output);
+    printf("Target:      %s\n\n", target_output);
+
+    unsigned char hash[32];
+    char hex_output[32 * 2 + 1];
+    for (int i = 0; i < 10; i++) {
+        block_header[0] = i;
+        double_sha256(block_header, sizeof(block_header), hash);
+
+        // Output the hash as a hexadecimal string
+        to_hex(hash, hex_output);
+        printf("Result Hash: %s\n", hex_output);
+
+        if (memcmp(hash, target, 32) < 0) {
+            printf("\nBlock header satisfies the difficulty target!\n");
+            break;
+        } else {
+            printf("Keep hashing...\n");
+        }
+    }
+
+    return 0;
+}

--- a/faycsic/main/hash.h
+++ b/faycsic/main/hash.h
@@ -1,0 +1,16 @@
+#ifndef SHA256_H
+#define SHA256_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stddef.h> // For size_t
+#include "esp_system.h"
+#include "mbedtls/sha256.h"
+
+// Function declaration
+void to_hex(unsigned char *hash, char output[]);
+void double_sha256(unsigned char *input, size_t len, uint8_t output[32]);
+int hash();
+
+#endif // SHA256_H

--- a/faycsic/main/main.c
+++ b/faycsic/main/main.c
@@ -1,7 +1,17 @@
 #include <stdio.h>
 #include "esp_log.h"
-
+#include "hash.h"
 void app_main(void)
 {
     ESP_LOGI("main", "Hello, world!");
+
+    // Example: Simplified Bitcoin block header
+    uint8_t block_header[80] = { /* 80 bytes of block header data */ };
+
+    // Check if hash meets the difficulty target
+    unsigned char target[32] = { /* Difficulty target */ };
+    target[0] = 0xf;
+
+    // run hash
+    hash(target, block_header);
 }


### PR DESCRIPTION
seems to work although during compilation there is a warning that may make a diff in whether it's really doing what we expect:

```
/home/biff/eng/fayksic/faycsic/main/hash.c: In function 'hash':
/home/biff/eng/fayksic/faycsic/main/hash.c:32:43: warning: 'sizeof' on array function parameter 'block_header' will return size of 'uint8_t *' {aka 'unsigned char *'} [-Wsizeof-array-argument]
   32 |         double_sha256(block_header, sizeof(block_header), hash);
      |                                           ^
/home/biff/eng/fayksic/faycsic/main/hash.c:23:44: note: declared here
   23 | int hash(unsigned char target[32], uint8_t block_header[80]) {
      |                                    ~~~~~~~~^~~~~~~~~~~~~~~~
```